### PR TITLE
[PP-2859] Update default log path for weep

### DIFF
--- a/docs/weep.md
+++ b/docs/weep.md
@@ -9,22 +9,27 @@ Weep is a CLI tool that manages AWS access via ConsoleMe for local development.
 ### Options
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-  -h, --help                help for weep
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+  -h, --help                       help for weep
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO
 
-* [weep completion](weep_completion.md)	 - Generate completion script
-* [weep credential_process](weep_credential_process.md)	 - Retrieve credentials and writes them in credential_process format
-* [weep ecs_credential_provider](weep_ecs_credential_provider.md)	 - Run a local ECS Credential Provider endpoint that serves and caches credentials for roles on demand
+* [weep console](weep_console.md)	 - Log into the AWS Management console
+* [weep credential_process](weep_credential_process.md)	 - Retrieve credentials on the fly via the AWS SDK
 * [weep export](weep_export.md)	 - Retrieve credentials to be exported as environment variables
 * [weep file](weep_file.md)	 - Retrieve credentials and save them to a credentials file
-* [weep generate_credential_process_config](weep_generate_credential_process_config.md)	 - Write all of your eligible roles as profiles in your AWS Config to source credentials from Weep
 * [weep list](weep_list.md)	 - List available roles
-* [weep metadata](weep_metadata.md)	 - Run a local Instance Metadata Service (IMDS) endpoint that serves credentials
+* [weep open](weep_open.md)	 - Generate (and open) a ConsoleMe link for a given ARN
+* [weep serve](weep_serve.md)	 - Run a local ECS Credential Provider endpoint that serves and caches credentials for roles on demand
 * [weep setup](weep_setup.md)	 - Print setup information
 * [weep version](weep_version.md)	 - Print version information
+* [weep whoami](weep_whoami.md)	 - Print information about current AWS credentials
 

--- a/docs/weep_console.md
+++ b/docs/weep_console.md
@@ -1,23 +1,23 @@
-## weep export
+## weep console
 
-Retrieve credentials to be exported as environment variables
+Log into the AWS Management console
 
 ### Synopsis
 
-The export command retrieves credentials for a role and prints a shell command to export 
-the credentials to environment variables.
-
-More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-export
+The login command opens a browser window with a link that will log you into the
+AWS Management console using the specified role. You can use the --no-open flag to simply print the console
+link, rather than opening it in a browser.
 
 
 ```
-weep export [role_name] [flags]
+weep console [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for export
+  -h, --help      help for console
+  -x, --no-open   print the link, but do not open a browser window
 ```
 
 ### Options inherited from parent commands

--- a/docs/weep_credential_process.md
+++ b/docs/weep_credential_process.md
@@ -1,6 +1,16 @@
 ## weep credential_process
 
-Retrieve credentials and writes them in credential_process format
+Retrieve credentials on the fly via the AWS SDK
+
+### Synopsis
+
+The credential_process command can be used by AWS SDKs to retrieve 
+credentials from Weep on the fly. The --generate flag lets you automatically
+generate an AWS configuration with profiles for all of your available roles, or 
+you can manually update your configuration (see the link below to learn how).
+
+More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-process
+
 
 ```
 weep credential_process [role_name] [flags]
@@ -9,16 +19,23 @@ weep credential_process [role_name] [flags]
 ### Options
 
 ```
-  -h, --help    help for credential_process
-  -n, --no-ip   remove IP restrictions
+  -g, --generate        generate ~/.aws/config with credential process config
+  -h, --help            help for credential_process
+  -o, --output string   output file for AWS config (default "/Users/mrowland/.aws/config")
+  -p, --pretty          when combined with --generate/-g, use 'account_name-role_name' format for generated profiles instead of arn
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO

--- a/docs/weep_file.md
+++ b/docs/weep_file.md
@@ -2,6 +2,15 @@
 
 Retrieve credentials and save them to a credentials file
 
+### Synopsis
+
+The file command writes role credentials to the AWS credentials file, usually 
+~/.aws/credentials. Since these credentials are static, you’ll have to re-run the command
+every hour to get new credentials.
+
+More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-file
+
+
 ```
 weep file [role_name] [flags]
 ```
@@ -9,18 +18,24 @@ weep file [role_name] [flags]
 ### Options
 
 ```
+  -f, --force            overwrite existing profile without prompting
   -h, --help             help for file
-  -n, --no-ip            remove IP restrictions
-  -o, --output string    output file for credentials (default "/Users/psanders/.aws/credentials")
-  -p, --profile string   profile name (default "consoleme")
+  -o, --output string    output file for credentials (default "/Users/mrowland/.aws/credentials")
+  -p, --profile string   profile name (default "default")
+  -R, --refresh          automatically refresh credentials in file
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO

--- a/docs/weep_list.md
+++ b/docs/weep_list.md
@@ -2,6 +2,15 @@
 
 List available roles
 
+### Synopsis
+
+The list command prints out all of the roles you have access to via ConsoleMe. By default,
+this command will only show console roles. Use the --all flag to also include application
+roles.
+
+More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/list-eligible-roles
+
+
 ```
 weep list [flags]
 ```
@@ -9,15 +18,26 @@ weep list [flags]
 ### Options
 
 ```
-  -h, --help   help for list
+  -a, --account string   filter by aws account number or account name
+      --all              show all available roles (default option) (default true)
+  -e, --extended-info    include additional information about roles such as associated apps
+  -h, --help             help for list
+  -i, --instance         show only instance roles
+  -p, --profiles         show only configured roles
+  -s, --short-info       only display the role ARNs
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO

--- a/docs/weep_open.md
+++ b/docs/weep_open.md
@@ -1,23 +1,23 @@
-## weep export
+## weep open
 
-Retrieve credentials to be exported as environment variables
+Generate (and open) a ConsoleMe link for a given ARN
 
 ### Synopsis
 
-The export command retrieves credentials for a role and prints a shell command to export 
-the credentials to environment variables.
-
-More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-export
+The open command generates the link for supported resources in ConsoleMe. By default, this command 
+also attempts to open the browser after generating the link. Use the --no-open flag to prevent opening. 
+The supported resources match those that are supported by ConsoleMe. IAM roles, s3, sqs and sns resources open in the ConsoleMe editor, while other supported resources attempt to redirect to the AWS Console using the right role.
 
 
 ```
-weep export [role_name] [flags]
+weep open <arn> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for export
+  -h, --help      help for open
+  -x, --no-open   don't automatically open links
 ```
 
 ### Options inherited from parent commands

--- a/docs/weep_serve.md
+++ b/docs/weep_serve.md
@@ -1,0 +1,51 @@
+## weep serve
+
+Run a local ECS Credential Provider endpoint that serves and caches credentials for roles on demand
+
+### Synopsis
+
+The serve command runs a local webserver that serves the /ecs/ path. When the
+AWS_CONTAINER_CREDENTIALS_FULL_URI environment variable is set to a URL, the 
+AWS CLI and SDKs will use that URL to retrieve credentials. For example, if 
+you want to use credentials for a role called SuperCoolRole, you could do 
+something like this:
+
+AWS_CONTAINER_CREDENTIALS_FULL_URI=http://localhost:9091/ecs/SuperCoolRole \
+        aws sts get-caller-identity
+
+If you just want to use a single role, use the 'role' positional argument to specify which one and it
+will be served the same way credentials are served in an EC2 instance. There’s no need
+to set an environment variable for this.
+
+More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-provider
+
+
+```
+weep serve [optional_role_name] [flags]
+```
+
+### Options
+
+```
+  -h, --help                    help for serve
+  -a, --listen-address string   IP address for the ECS credential provider to listen on (default "127.0.0.1")
+  -p, --port int                port for the ECS credential provider service to listen on (default 9091)
+```
+
+### Options inherited from parent commands
+
+```
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
+```
+
+### SEE ALSO
+
+* [weep](weep.md)	 - weep helps you get the most out of ConsoleMe credentials
+

--- a/docs/weep_setup.md
+++ b/docs/weep_setup.md
@@ -2,6 +2,25 @@
 
 Print setup information
 
+### Synopsis
+
+By default, this command will print a script that can be used to set up IMDS routing.
+If you trust us enough, you can let Weep do all the work for you:
+
+sudo weep setup --commit
+
+Otherwise, run weep setup and inspect the output. Then save the output to a file or pass it to your shell:
+
+# Pass to shell
+weep setup  # trust no one, always inspect
+weep setup | sudo sh
+
+# Save to file
+weep setup > setup.sh
+cat setup.sh  # trust no one, always inspect
+chmod u+x setup.sh
+sudo ./setup.sh
+
 ```
 weep setup [flags]
 ```
@@ -9,15 +28,21 @@ weep setup [flags]
 ### Options
 
 ```
-  -h, --help   help for setup
+  -C, --commit   install all the things (probably requires root, definitely requires trust)
+  -h, --help     help for setup
 ```
 
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO

--- a/docs/weep_version.md
+++ b/docs/weep_version.md
@@ -15,9 +15,14 @@ weep version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       config file (default is $HOME/.weep.yaml)
-      --log-format string   log format (json or tty)
-      --log-level string    log level (debug, info, warn)
+  -A, --assume-role strings        one or more roles to assume after retrieving credentials
+  -c, --config string              config file (default is $HOME/.weep.yaml)
+      --extra-config-file string   extra-config-file <yaml_file>
+      --log-file string            log file path (default "/tmp/weep.log")
+      --log-format string          log format (json or tty)
+      --log-level string           log level (debug, info, warn)
+  -n, --no-ip                      remove IP restrictions
+  -r, --region string              AWS region (default "us-east-1")
 ```
 
 ### SEE ALSO

--- a/docs/weep_whoami.md
+++ b/docs/weep_whoami.md
@@ -1,23 +1,21 @@
-## weep export
+## weep whoami
 
-Retrieve credentials to be exported as environment variables
+Print information about current AWS credentials
 
 ### Synopsis
 
-The export command retrieves credentials for a role and prints a shell command to export 
-the credentials to environment variables.
-
-More information: https://hawkins.gitbook.io/consoleme/weep-cli/commands/credential-export
-
+The whoami command retrieves information about your AWS credentials from AWS STS using the default
+credential provider chain. If SWAG (https://github.com/Netflix-Skunkworks/swag-api) is enabled, weep will
+attempt to enrich the output with additional data.
 
 ```
-weep export [role_name] [flags]
+weep whoami [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for export
+  -h, --help   help for whoami
 ```
 
 ### Options inherited from parent commands

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,11 +55,12 @@ func init() {
 }
 
 func getDefaultLogFile() string {
+	user := os.Getenv("USER")
 	switch os := runtime.GOOS; os {
 	case "darwin":
-		return filepath.Join("/", "tmp", "weep.log")
+		return filepath.Join("/", "tmp", user, "weep.log")
 	case "linux":
-		return filepath.Join("/", "tmp", "weep.log")
+		return filepath.Join("/", "tmp", user, "weep.log")
 	case "windows":
 		p, _ := filepath.Abs(filepath.FromSlash("/programdata/weep/weep.log"))
 		return p

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -56,13 +57,17 @@ func init() {
 
 func getDefaultLogFile() string {
 	user := os.Getenv("USER")
+	logFile := "weep.log"
+	if user != "" {
+		logFile = fmt.Sprintf("%s.log", user)
+	}
 	switch os := runtime.GOOS; os {
 	case "darwin":
-		return filepath.Join("/", "tmp", user, "weep.log")
+		return filepath.Join("/", "tmp", "weep", logFile)
 	case "linux":
-		return filepath.Join("/", "tmp", user, "weep.log")
+		return filepath.Join("/", "tmp", "weep", logFile)
 	case "windows":
-		p, _ := filepath.Abs(filepath.FromSlash("/programdata/weep/weep.log"))
+		p, _ := filepath.Abs(filepath.FromSlash(fmt.Sprintf("/programdata/weep/%s", logFile)))
 		return p
 	default:
 		return ""


### PR DESCRIPTION
if `$USER` is set on the current env, log to `/tmp/weep/${USER}.log`. Else log to `/tmp/weep/weep.log`. 

This should help greatly in multi-user scenarios where logs are being written to `/tmp/weep.log` owned by one user (as default perms `664`), causing other user's weep calls to fail. 